### PR TITLE
Fix package version schema

### DIFF
--- a/python-pyfire-0.3.4/debian/changelog
+++ b/python-pyfire-0.3.4/debian/changelog
@@ -1,4 +1,10 @@
-python-pyfire (0.3.4-1ubuntu3) trusty; urgency=medium
+python-pyfire (0.3.4-2) trusty; urgency=low
+
+  * Fixing version schema
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Fri, 09 May 2014 14:52:49 -0300
+
+python-pyfire (0.3.4-1ubuntu3) trusty; urgency=low
 
   * Creating pure debhelper package
 

--- a/snakefire-1.0.6/debian/changelog
+++ b/snakefire-1.0.6/debian/changelog
@@ -1,3 +1,9 @@
+snakefire (1.0.6-2) trusty; urgency=low
+
+  * Fixing package version schema
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Fri, 09 May 2014 14:39:48 -0300
+
 snakefire (1.0.6-1ubuntu0) trusty; urgency=low
 
   * Fixing python version; Changing package to quilt; Renaming .desktop file


### PR DESCRIPTION
During package building, these warnings are generated:

``` term
dpkg-source: warning: Version number suggests Ubuntu changes, but Maintainer: does not have Ubuntu address
dpkg-source: warning: Version number suggests Ubuntu changes, but there is no XSBC-Original-Maintainer field
```

Fix package version schema in all packages to fix them.
