### PR TITLE
Make SSL connection ON by default

### DIFF
--- a/snakefire-1.0.5/debian/changelog
+++ b/snakefire-1.0.5/debian/changelog
@@ -1,3 +1,9 @@
+snakefire (1.0.5-3) trusty; urgency=low
+
+  * SSL is now ON by default
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Wed, 14 May 2014 10:21:04 -0300
+
 snakefire (1.0.5-2) trusty; urgency=low
 
   * Fixing .desktop file to match new desktop.org standards

--- a/snakefire-1.0.5/snakefire/mainframe.py
+++ b/snakefire-1.0.5/snakefire/mainframe.py
@@ -136,7 +136,7 @@ class Snakefire(object):
                 "subdomain": None,
                 "user": None,
                 "password": None,
-                "ssl": False,
+                "ssl": True,
                 "connect": False,
                 "join": False,
                 "rooms": []


### PR DESCRIPTION
Basecamp made SSL the default for all new accounts (check [here](http://37signals.blogs.com/products/2009/07/good-citizen-update-now-all-basecamp-plans-include-ssl-security.html)).

At `mainframe.py`, change `ssl` to be `True` by default.
